### PR TITLE
Add one-to-one, one-to-many, many-to-one and many-to-many Dijkstra searches

### DIFF
--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -68,8 +68,9 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
     }
 
     /**
-     * Do a Dijkstra search from the given start node.
+     * Do a Dijkstra search from the given start node to all other nodes.
      */
+    // TODO: Add a unit test for this.
     @Override
     public void calculate(V startNode) {
 
@@ -288,6 +289,9 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
     /**
      * Performs a Dijkstra search from each source, each time stopping once the
      * target has been found.
+     *
+     * Note: This is not very efficient since a separate search is required from
+     * each start node. TODO: Optimize!
      *
      * @param sources Sources
      * @param target  Target

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -191,20 +191,22 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
      * @param source Source
      * @param target Target
      *
-     * @return A map of distances from the source keyed by the target.
+     * @return The distance from the source to the target.
      */
-    public void oneToOne(V source, final V target) {
+    public double oneToOne(V source, final V target) {
         if (source == null) {
             throw new IllegalArgumentException(
-                    "Please specify at least one source.");
+                    "Please specify a source.");
         } else if (target == null) {
             throw new IllegalArgumentException(
-                    "Please specify at least one target.");
+                    "Please specify a target.");
         } else {
             // If source=target, then no search is necessary.
             if (source.equals(target)) {
                 // So just set the distance.
                 source.setSource();
+                // and return it.
+                return source.getDistance();
             } else {
                 // Otherwise we have to search.
                 new Dijkstra<V, E>(graph) {
@@ -218,6 +220,8 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
                         return false;
                     }
                 }.calculate(source);
+                // Return the distance to the target.
+                return target.getDistance();
             }
         }
     }

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -237,6 +237,8 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
      *
      * @param source  Source
      * @param targets Targets
+     *
+     * @return A map of distances from the source keyed by the target vertex.
      */
     public Map<V, Double> oneToMany(V source, final Set<V> targets) {
         if (targets.isEmpty()) {
@@ -277,6 +279,30 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
                         return false;
                     }
                 }.calculate(source);
+            }
+            return distances;
+        }
+    }
+
+    /**
+     * Performs a Dijkstra search from each source, each time stopping once the
+     * target has been found.
+     *
+     * @param sources Sources
+     * @param target  Target
+     *
+     * @return A map of the distance to the target keyed by the source vertex.
+     */
+    public Map<V, Double> manyToOne(final Set<V> sources, V target) {
+        if (sources.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Please specify at least one source.");
+        } else {
+            final Map<V, Double> distances = new HashMap<V, Double>();
+
+            for (V source : sources) {
+                double distance = oneToOne(source, target);
+                distances.put(source, distance);
             }
             return distances;
         }

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -26,6 +26,8 @@ package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VSearch;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.PriorityQueue;
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
@@ -74,7 +76,9 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
             // Extract the minimum element.
             V u = queue.poll();
             // Do any pre-relax step.
-            preRelaxStep(startNode, u);
+            if (preRelaxStep(startNode, u)) {
+                break;
+            }
             // Relax all the outgoing edges of u.
             for (E e : outgoingEdgesOf(u)) {
                 relax(u, e, queue);
@@ -94,8 +98,11 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
      * u. In this class, it is empty on purpose.
      *
      * @param u Vertex u.
+     *
+     * @return false if we should stop the Dijkstra search.
      */
-    protected void preRelaxStep(V startNode, V u) {
+    protected boolean preRelaxStep(V startNode, V u) {
+        return false;
     }
 
     /**
@@ -175,5 +182,43 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
                         v2.getDistance());
             }
         });
+    }
+
+    /**
+     * Performs a Dijkstra search from the source, stopping once the target is
+     * found.
+     *
+     * @param source Source
+     * @param target Target
+     *
+     * @return A map of distances from the source keyed by the target.
+     */
+    public void oneToOne(V source, final V target) {
+        if (source == null) {
+            throw new IllegalArgumentException(
+                    "Please specify at least one source.");
+        } else if (target == null) {
+            throw new IllegalArgumentException(
+                    "Please specify at least one target.");
+        } else {
+            // If source=target, then no search is necessary.
+            if (source.equals(target)) {
+                // So just set the distance.
+                source.setSource();
+            } else {
+                // Otherwise we have to search.
+                new Dijkstra<V, E>(graph) {
+                    @Override
+                    protected boolean preRelaxStep(V startNode, V u) {
+                        // If we have reached the target, then stop the search.
+                        if (u.equals(target)) {
+                            return true;
+                        }
+                        // Otherwise we have to keep going.
+                        return false;
+                    }
+                }.calculate(source);
+            }
+        }
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 import org.javanetworkanalyzer.data.VSearch;
+import org.javanetworkanalyzer.data.VWBetw;
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 
@@ -303,6 +304,35 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
             for (V source : sources) {
                 double distance = oneToOne(source, target);
                 distances.put(source, distance);
+            }
+            return distances;
+        }
+    }
+
+    /**
+     * Performs a Dijkstra search from each source to each target using a
+     * {@link #oneToMany(org.javanetworkanalyzer.data.VWBetw, java.util.Set)}
+     * search from each source.
+     *
+     * Note: Using oneToMany rather than manyToOne is more efficient.
+     *
+     * @param sources Sources
+     * @param targets Targets
+     *
+     * @return A map of maps of distances. The first V is keyed by the source
+     *         and the second V is keyed by the target.
+     */
+    public Map<V, Map<V, Double>> manyToMany(final Set<V> sources,
+                                             final Set<V> targets) {
+        if (sources.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Please specify at least one source.");
+        } else {
+            final Map<V, Map<V, Double>> distances =
+                    new HashMap<V, Map<V, Double>>();
+            for (V source : sources) {
+                Map<V, Double> oneToMany = oneToMany(source, targets);
+                distances.put(source, oneToMany);
             }
             return distances;
         }

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -27,8 +27,9 @@ package org.javanetworkanalyzer.alg;
 import org.javanetworkanalyzer.data.VSearch;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
 import java.util.PriorityQueue;
+import java.util.Set;
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 
@@ -219,6 +220,48 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
                     }
                 }.calculate(source);
             }
+        }
+    }
+
+    /**
+     * Performs a Dijkstra search from the source, stopping once the all the
+     * targets are found.
+     *
+     * @param source  Source
+     * @param targets Targets
+     */
+    public void oneToMany(V source, final Set<V> targets) {
+        if (targets.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Please specify at least one target.");
+        } else if (targets.size() == 1) {
+            oneToOne(source, targets.iterator().next());
+        } else {
+
+            // Use a copy of targets so that we can still refer
+            // to targets later to recover the distances.
+            final Set<V> destinations = new HashSet<V>(targets);
+
+            // Instead of looping through the targets and using oneToOne (which
+            // would require one search per target), we do just one search until
+            // all targets are found.
+            new Dijkstra<V, E>(graph) {
+                @Override
+                protected boolean preRelaxStep(V startNode, V u) {
+                    // If there are no more targets, then stop the search.
+                    if (destinations.isEmpty()) {
+                        return true;
+                    } else {
+                        // If u is  a target, then remove it.
+                        destinations.remove(u);
+                        // If there are no more targets, then stop the search.
+                        if (destinations.isEmpty()) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            }.calculate(source);
         }
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -90,6 +90,9 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
 
     @Override
     protected void init(V startNode) {
+        for (V node : graph.vertexSet()) {
+            node.setDistance(Double.POSITIVE_INFINITY);
+        }
         startNode.setSource();
         queue.clear();
         queue.add(startNode);

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -24,12 +24,11 @@
  */
 package org.javanetworkanalyzer.alg;
 
-import org.javanetworkanalyzer.data.VSearch;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.PriorityQueue;
 import java.util.Set;
+import org.javanetworkanalyzer.data.VSearch;
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -59,8 +59,7 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
     /**
      * Constructs a new {@link Dijkstra} object.
      *
-     * @param graph     The graph.
-     * @param startNode The start node.
+     * @param graph The graph.
      */
     public Dijkstra(Graph<V, E> graph) {
         super(graph);
@@ -287,8 +286,8 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
     }
 
     /**
-     * Performs a Dijkstra search from each source, each time stopping once the
-     * target has been found.
+     * Performs a Dijkstra search from each source to the given target using a
+     * {@link #oneToOne}.
      *
      * Note: This is not very efficient since a separate search is required from
      * each start node. TODO: Optimize!
@@ -315,8 +314,7 @@ public class Dijkstra<V extends VSearch<V, Double>, E>
 
     /**
      * Performs a Dijkstra search from each source to each target using a
-     * {@link #oneToMany(org.javanetworkanalyzer.data.VWBetw, java.util.Set)}
-     * search from each source.
+     * {@link #oneToMany} search from each source.
      *
      * Note: Using oneToMany rather than manyToOne is more efficient.
      *

--- a/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
@@ -80,8 +80,7 @@ public class DijkstraForCentrality<E>
      * @param u Vertex u.
      */
     @Override
-    protected void preRelaxStep(VWBetw startNode,
-                                VWBetw u) {
+    protected boolean preRelaxStep(VWBetw startNode, VWBetw u) {
         // Push it to the stack.
         if (canPushToStack(u)) {
             stack.push(u);
@@ -93,6 +92,8 @@ public class DijkstraForCentrality<E>
         if (!u.equals(startNode)) {
             pathsFromStartNode.addSPLength(u.getDistance());
         }
+        // Don't stop the search.
+        return false;
     }
 
     /**

--- a/src/test/java/org/javanetworkanalyzer/alg/DijkstraTest.java
+++ b/src/test/java/org/javanetworkanalyzer/alg/DijkstraTest.java
@@ -1,0 +1,221 @@
+/**
+ * Java Network Analyzer provides a collection of graph theory and social
+ * network analysis algorithms implemented on mathematical graphs using the
+ * <a href="http://www.jgrapht.org/">JGraphT</a> library.
+ *
+ * Java Network Analyzer is distributed under the GPL 3 license. It is produced
+ * by the "Atelier SIG" team of the <a href="http://www.irstv.fr">IRSTV
+ * Institute</a>, CNRS FR 2488.
+ *
+ * Copyright 2013 IRSTV (CNRS FR 2488).
+ *
+ * Java Network Analyzer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Java Network Analyzer is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Java Network Analyzer. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.javanetworkanalyzer.alg;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.javanetworkanalyzer.data.VWBetw;
+import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.model.WeightedPseudoG;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests one-to-one, one-to-many, many-to-one and many-to-many Dijkstra searches
+ * on the Cormen graph.
+ *
+ * In each test we consider all possible combinations, so that all distances
+ * between pairs of nodes are calculated.
+ *
+ * @author Adam Gouge
+ */
+//                   1
+//           >2 ------------>3
+//          / |^           ->|^
+//       10/ / |      9   / / |
+//        / 2| |3    -----  | |
+//       /   | |    /      4| |6
+//      1<---------------   | |
+//       \   | |  /     7\  | |
+//       5\  | / /        \ | /
+//         \ v| /    2     \v|
+//          > 4 -----------> 5
+//               CORMEN
+public class DijkstraTest {
+
+    private static final double TOLERANCE = 0.0;
+
+    @Test
+    public void testOneToOne() {
+        try {
+            WeightedPseudoG<VWBetw, Edge> g = prepareGraph();
+            Map<VWBetw, Map<VWBetw, Double>> expectedDistances =
+                    expectedDistances(g);
+
+            Dijkstra<VWBetw, Edge> dijkstra = new Dijkstra<VWBetw, Edge>(g);
+
+            for (VWBetw source : g.vertexSet()) {
+                for (VWBetw target : g.vertexSet()) {
+                    double distance = dijkstra.oneToOne(source, target);
+                    assertEquals(expectedDistances.get(source).get(target),
+                                 distance, TOLERANCE);
+                }
+            }
+        } catch (NoSuchMethodException ex) {
+        }
+    }
+
+    @Test
+    public void testOneToMany() {
+        try {
+            WeightedPseudoG<VWBetw, Edge> g = prepareGraph();
+            Map<VWBetw, Map<VWBetw, Double>> expectedDistances =
+                    expectedDistances(g);
+
+            Dijkstra<VWBetw, Edge> dijkstra = new Dijkstra<VWBetw, Edge>(g);
+
+            for (VWBetw source : g.vertexSet()) {
+                // Note: This is a oneToAll. It should be equivalent to
+                // dijkstra.calculate(source);
+                Map<VWBetw, Double> distances =
+                        dijkstra.oneToMany(source, g.vertexSet());
+                for (Entry<VWBetw, Double> e : distances.entrySet()) {
+                    VWBetw target = e.getKey();
+                    Double distance = e.getValue();
+                    assertEquals(expectedDistances.get(source).get(target),
+                                 distance, TOLERANCE);
+                }
+            }
+        } catch (NoSuchMethodException ex) {
+        }
+    }
+
+    @Test
+    public void testManyToOne() {
+        try {
+            WeightedPseudoG<VWBetw, Edge> g = prepareGraph();
+            Map<VWBetw, Map<VWBetw, Double>> expectedDistances =
+                    expectedDistances(g);
+
+            Dijkstra<VWBetw, Edge> dijkstra = new Dijkstra<VWBetw, Edge>(g);
+
+            for (VWBetw target : g.vertexSet()) {
+                // Note: This is an allToOne.
+                Map<VWBetw, Double> distances =
+                        dijkstra.manyToOne(g.vertexSet(), target);
+                for (Entry<VWBetw, Double> e : distances.entrySet()) {
+                    VWBetw source = e.getKey();
+                    Double distance = e.getValue();
+                    assertEquals(expectedDistances.get(source).get(target),
+                                 distance, TOLERANCE);
+                }
+            }
+        } catch (NoSuchMethodException ex) {
+        }
+    }
+
+    @Test
+    public void testManyToMany() {
+        try {
+            WeightedPseudoG<VWBetw, Edge> g = prepareGraph();
+            Map<VWBetw, Map<VWBetw, Double>> expectedDistances =
+                    expectedDistances(g);
+
+            Dijkstra<VWBetw, Edge> dijkstra = new Dijkstra<VWBetw, Edge>(g);
+
+            // Note: This is an allToAll.
+            Map<VWBetw, Map<VWBetw, Double>> distances =
+                    dijkstra.manyToMany(g.vertexSet(), g.vertexSet());
+            for (Entry<VWBetw, Map<VWBetw, Double>> e : distances.entrySet()) {
+                VWBetw source = e.getKey();
+                Map<VWBetw, Double> distancesKeyedByTarget = e.getValue();
+                for (Entry<VWBetw, Double> f : distancesKeyedByTarget.entrySet()) {
+                    VWBetw target = f.getKey();
+                    double distance = f.getValue();
+                    assertEquals(expectedDistances.get(source).get(target),
+                                 distance, TOLERANCE);
+                }
+            }
+        } catch (NoSuchMethodException ex) {
+        }
+    }
+
+    private WeightedPseudoG<VWBetw, Edge> prepareGraph()
+            throws NoSuchMethodException {
+        WeightedPseudoG<VWBetw, Edge> graph = new WeightedPseudoG<VWBetw, Edge>(
+                VWBetw.class, Edge.class);
+        graph.addEdge(1, 2).setWeight(10);
+        graph.addEdge(1, 4).setWeight(5);
+        graph.addEdge(5, 1).setWeight(7);
+        graph.addEdge(2, 4).setWeight(2);
+        graph.addEdge(4, 2).setWeight(3);
+        graph.addEdge(3, 5).setWeight(4);
+        graph.addEdge(2, 3).setWeight(1);
+        graph.addEdge(4, 3).setWeight(9);
+        graph.addEdge(5, 3).setWeight(6);
+        graph.addEdge(4, 5).setWeight(2);
+        return graph;
+    }
+
+    private Map<VWBetw, Map<VWBetw, Double>> expectedDistances(
+            WeightedPseudoG<VWBetw, Edge> g) {
+        Map<VWBetw, Map<VWBetw, Double>> distances =
+                new HashMap<VWBetw, Map<VWBetw, Double>>();
+
+        Map<VWBetw, Double> dFromOne = new HashMap<VWBetw, Double>();
+        dFromOne.put(g.getVertex(1), 0.0);
+        dFromOne.put(g.getVertex(2), 7.0);
+        dFromOne.put(g.getVertex(3), 8.0);
+        dFromOne.put(g.getVertex(4), 5.0);
+        dFromOne.put(g.getVertex(5), 7.0);
+
+        Map<VWBetw, Double> dFromTwo = new HashMap<VWBetw, Double>();
+        dFromTwo.put(g.getVertex(1), 7.0);
+        dFromTwo.put(g.getVertex(2), 0.0);
+        dFromTwo.put(g.getVertex(3), 1.0);
+        dFromTwo.put(g.getVertex(4), 2.0);
+        dFromTwo.put(g.getVertex(5), 4.0);
+
+        Map<VWBetw, Double> dFromThree = new HashMap<VWBetw, Double>();
+        dFromThree.put(g.getVertex(1), 8.0);
+        dFromThree.put(g.getVertex(2), 1.0);
+        dFromThree.put(g.getVertex(3), 0.0);
+        dFromThree.put(g.getVertex(4), 3.0);
+        dFromThree.put(g.getVertex(5), 4.0);
+
+        Map<VWBetw, Double> dFromFour = new HashMap<VWBetw, Double>();
+        dFromFour.put(g.getVertex(1), 5.0);
+        dFromFour.put(g.getVertex(2), 2.0);
+        dFromFour.put(g.getVertex(3), 3.0);
+        dFromFour.put(g.getVertex(4), 0.0);
+        dFromFour.put(g.getVertex(5), 2.0);
+
+        Map<VWBetw, Double> dFromFive = new HashMap<VWBetw, Double>();
+        dFromFive.put(g.getVertex(1), 7.0);
+        dFromFive.put(g.getVertex(2), 4.0);
+        dFromFive.put(g.getVertex(3), 4.0);
+        dFromFive.put(g.getVertex(4), 2.0);
+        dFromFive.put(g.getVertex(5), 0.0);
+
+        distances.put(g.getVertex(1), dFromOne);
+        distances.put(g.getVertex(2), dFromTwo);
+        distances.put(g.getVertex(3), dFromThree);
+        distances.put(g.getVertex(4), dFromFour);
+        distances.put(g.getVertex(5), dFromFive);
+
+        return distances;
+    }
+}


### PR DESCRIPTION
Being able to stop a Dijkstra search once a given node or a given set of nodes has been found is a big advantage in terms of saving time (one-to-one, one-to-many).

It is also interesting to be able to calculate distance tables from an arbitrary set of nodes to another arbitrary set of nodes. These methods add that functionality, returning
- one-to-one: `double` (distance from source to target)
- one-to-many: `Map<V, Double>` (distance from source keyed by target)
- many-to-one: `Map<V, Double>`  (distance to target keyed by source)
- many-to-many: `Map<V, Map<V, Double>>` (distance from source to target, keyed first by source, then by target)
