### PR TITLE
Fix betweenness normalization

### DIFF
--- a/src/main/java/org/javanetworkanalyzer/analyzers/GraphAnalyzer.java
+++ b/src/main/java/org/javanetworkanalyzer/analyzers/GraphAnalyzer.java
@@ -283,14 +283,17 @@ public abstract class GraphAnalyzer<V extends VBetw, E, S extends PathLengthData
      * set to 1.0.
      */
     private void normalizeBetweenness() {
-        findExtremeBetweennessValues();
-
         long start = System.currentTimeMillis();
+        findExtremeBetweennessValues();
         final double denominator = maxBetweenness - minBetweenness;
-        for (V node : nodeSet) {
-            final double normalizedBetweenness =
-                    (node.getBetweenness() - minBetweenness) / denominator;
-            node.setBetweenness(normalizedBetweenness);
+        if (denominator == 0.0) {
+            LOGGER.warn("All betweenness values are zero.");
+        } else {
+            for (V node : nodeSet) {
+                final double normalizedBetweenness =
+                        (node.getBetweenness() - minBetweenness) / denominator;
+                node.setBetweenness(normalizedBetweenness);
+            }
         }
         long stop = System.currentTimeMillis();
         LOGGER.info("({} ms) Betweenness normalization.", (stop - start));


### PR DESCRIPTION
This checks to make sure the max betweenness is not equal to the min betweenness. If so, we issue a warning saying that all betweenness values are zero. Otherwise, we do the normalization.
