### PR TITLE
Implement edge betweenness [#33]

### DIFF
--- a/src/main/java/org/javanetworkanalyzer/alg/BFS.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/BFS.java
@@ -25,6 +25,7 @@
 package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VBFS;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 
@@ -41,7 +42,7 @@ import java.util.Set;
  *            of BFS.
  * @author Adam Gouge
  */
-public class BFS<V extends VBFS, E>
+public class BFS<V extends VBFS, E extends EdgeSPT>
         extends GraphSearchAlgorithm<V, E> {
 
     /**

--- a/src/main/java/org/javanetworkanalyzer/alg/BFSForCentrality.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/BFSForCentrality.java
@@ -35,7 +35,8 @@ import org.jgrapht.Graph;
  *
  * @author Adam Gouge
  */
-public class BFSForCentrality<E> extends BFS<VUCent, E> {
+public class BFSForCentrality<E> extends BFS<VUCent, E>
+        implements CentralityAlg<VUCent, E, UnweightedPathLengthData> {
 
     /**
      * Stack that will return the nodes ordered by non-increasing distance from
@@ -102,6 +103,7 @@ public class BFSForCentrality<E> extends BFS<VUCent, E> {
         neighbor.accumulateSPCount(current.getSPCount());
     }
 
+    @Override
     public UnweightedPathLengthData getPaths() {
         return pathsFromStartNode;
     }

--- a/src/main/java/org/javanetworkanalyzer/alg/BFSForCentrality.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/BFSForCentrality.java
@@ -28,6 +28,7 @@ import org.javanetworkanalyzer.data.UnweightedPathLengthData;
 import java.util.LinkedList;
 import java.util.Stack;
 import org.javanetworkanalyzer.data.VUCent;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.Graph;
 
 /**
@@ -35,7 +36,7 @@ import org.jgrapht.Graph;
  *
  * @author Adam Gouge
  */
-public class BFSForCentrality<E> extends BFS<VUCent, E>
+public class BFSForCentrality<E extends EdgeSPT> extends BFS<VUCent, E>
         implements CentralityAlg<VUCent, E, UnweightedPathLengthData> {
 
     /**

--- a/src/main/java/org/javanetworkanalyzer/alg/CentralityAlg.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/CentralityAlg.java
@@ -3,6 +3,7 @@ package org.javanetworkanalyzer.alg;
 import org.javanetworkanalyzer.data.PathLengthData;
 import org.javanetworkanalyzer.data.VCent;
 import org.javanetworkanalyzer.data.VPred;
+import org.javanetworkanalyzer.model.EdgeSPT;
 
 /**
  * Root interface for {@link GraphSearchAlgorithm}s that do centrality
@@ -10,7 +11,7 @@ import org.javanetworkanalyzer.data.VPred;
  *
  * @author Adam Gouge
  */
-public interface CentralityAlg<V extends VCent, E, S extends PathLengthData>
+public interface CentralityAlg<V extends VCent, E extends EdgeSPT, S extends PathLengthData>
         extends TraversalAlg<V, E> {
 
     /**

--- a/src/main/java/org/javanetworkanalyzer/alg/CentralityAlg.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/CentralityAlg.java
@@ -1,0 +1,22 @@
+package org.javanetworkanalyzer.alg;
+
+import org.javanetworkanalyzer.data.PathLengthData;
+import org.javanetworkanalyzer.data.VCent;
+import org.javanetworkanalyzer.data.VPred;
+
+/**
+ * Root interface for {@link GraphSearchAlgorithm}s that do centrality
+ * calculations.
+ *
+ * @author Adam Gouge
+ */
+public interface CentralityAlg<V extends VCent, E, S extends PathLengthData>
+        extends TraversalAlg<V, E> {
+
+    /**
+     * Returns the path length data.
+     *
+     * @return The path length data
+     */
+    S getPaths();
+}

--- a/src/main/java/org/javanetworkanalyzer/alg/DFS.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DFS.java
@@ -25,6 +25,7 @@
 package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VDFS;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.Graph;
 
 /**
@@ -34,7 +35,7 @@ import org.jgrapht.Graph;
  *            of DFS.
  * @author Adam Gouge
  */
-public class DFS<V extends VDFS, E> extends GraphSearchAlgorithm<V, E> {
+public class DFS<V extends VDFS, E extends EdgeSPT> extends GraphSearchAlgorithm<V, E> {
 
     /**
      * For discovery and finishing times.

--- a/src/main/java/org/javanetworkanalyzer/alg/DFSForStrahler.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DFSForStrahler.java
@@ -26,6 +26,8 @@ package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VStrahler;
 import java.util.List;
+
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.Graph;
 
 /**
@@ -42,7 +44,7 @@ import org.jgrapht.Graph;
  *
  * @author Adam Gouge
  */
-public class DFSForStrahler<E> extends DFS<VStrahler, E> {
+public class DFSForStrahler<E extends EdgeSPT> extends DFS<VStrahler, E> {
 
     /**
      * Constructor.

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -25,6 +25,7 @@
 package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VDijkstra;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
@@ -39,7 +40,7 @@ import java.util.*;
  * @param <E> Edges
  * @author Adam Gouge
  */
-public class Dijkstra<V extends VDijkstra, E>
+public class Dijkstra<V extends VDijkstra, E extends EdgeSPT>
         extends GraphSearchAlgorithm<V, E> {
 
     /**

--- a/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/Dijkstra.java
@@ -64,11 +64,8 @@ public class Dijkstra<V extends VDijkstra, E>
 
     /**
      * Does a Dijkstra search from the given start node to all other nodes.
-     * The shortest path "tree" we return may contain multiple shortest paths.
-     *
      *
      * @param startNode Start node
-     * @return The SPT if {@link #returnSPT} is true; null otherwise.
      */
     @Override
     public void calculate(V startNode) {

--- a/src/main/java/org/javanetworkanalyzer/alg/DijkstraForAccessibility.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DijkstraForAccessibility.java
@@ -26,6 +26,7 @@ package org.javanetworkanalyzer.alg;
 
 import java.util.PriorityQueue;
 import org.javanetworkanalyzer.data.VAccess;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.Graph;
 
 /**
@@ -36,7 +37,7 @@ import org.jgrapht.Graph;
  * @author Adam Gouge
  */
 // TODO: Enable **multiple** "closest" destinations within a given tolerance.
-public class DijkstraForAccessibility<E> extends Dijkstra<VAccess, E> {
+public class DijkstraForAccessibility<E extends EdgeSPT> extends Dijkstra<VAccess, E> {
 
     /**
      * Constructor: sets the graph.

--- a/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
@@ -36,7 +36,8 @@ import org.jgrapht.Graph;
  *
  * @author Adam Gouge
  */
-public class DijkstraForCentrality<E> extends Dijkstra<VWCent, E> {
+public class DijkstraForCentrality<E> extends Dijkstra<VWCent, E>
+        implements CentralityAlg<VWCent, E, WeightedPathLengthData> {
 
     /**
      * Stack that will return the nodes ordered by non-increasing distance from
@@ -126,11 +127,7 @@ public class DijkstraForCentrality<E> extends Dijkstra<VWCent, E> {
         super.multipleShortestPathUpdate(u, v, e);
     }
 
-    /**
-     * Returns the path length data.
-     *
-     * @return The path length data
-     */
+    @Override
     public WeightedPathLengthData getPaths() {
         return pathsFromStartNode;
     }

--- a/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/DijkstraForCentrality.java
@@ -28,6 +28,8 @@ import org.javanetworkanalyzer.data.VWCent;
 import org.javanetworkanalyzer.data.WeightedPathLengthData;
 import java.util.PriorityQueue;
 import java.util.Stack;
+
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.Graph;
 
 /**
@@ -36,7 +38,7 @@ import org.jgrapht.Graph;
  *
  * @author Adam Gouge
  */
-public class DijkstraForCentrality<E> extends Dijkstra<VWCent, E>
+public class DijkstraForCentrality<E extends EdgeSPT> extends Dijkstra<VWCent, E>
         implements CentralityAlg<VWCent, E, WeightedPathLengthData> {
 
     /**

--- a/src/main/java/org/javanetworkanalyzer/alg/GraphSearchAlgorithm.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/GraphSearchAlgorithm.java
@@ -42,7 +42,8 @@ import java.util.Set;
  * @param <E> Edges
  * @author Adam Gouge
  */
-public abstract class GraphSearchAlgorithm<V extends VPred, E> {
+public abstract class GraphSearchAlgorithm<V extends VPred, E>
+        implements TraversalAlg<V, E> {
 
     /**
      * The graph on which to calculate shortest paths.
@@ -57,28 +58,24 @@ public abstract class GraphSearchAlgorithm<V extends VPred, E> {
      * Constructor. The user can specify whether SPTs/traversal graphs are
      * calculated.
      *
-     * @param graph     The graph
+     * @param graph The graph
      */
     public GraphSearchAlgorithm(Graph<V, E> graph) {
         this.graph = graph;
     }
 
     /**
-     * Performs the graph search algorithm from the given start node.
+     * Performs any initializations to be done at the start of the
+     * {@link #calculate} method.
      *
      * @param startNode Start node
      */
-    protected abstract void calculate(V startNode);
+    protected void init(V startNode) {
+        this.currentStartNode = startNode;
+    }
 
-    /**
-     * Returns the SPT (BFS/Dijkstra) or traversal graph (DFS) from the last
-     * start node {@link #calculate} was called on. For BFS/Dijkstra, the
-     * shortest path "tree" we return may contain multiple shortest paths.
-     *
-     * @return The SPT/traversal graph from the last start node {@link #calculate}
-     *         was called on
-     */
-    protected TraversalGraph<V, E> reconstructTraversalGraph() {
+    @Override
+    public TraversalGraph<V, E> reconstructTraversalGraph() {
 
         if (currentStartNode == null) {
             throw new IllegalStateException("You must call #calculate before " +
@@ -108,16 +105,6 @@ public abstract class GraphSearchAlgorithm<V extends VPred, E> {
     }
 
     /**
-     * Performs any initializations to be done at the start of the
-     * {@link #calculate} method.
-     *
-     * @param startNode Start node
-     */
-    protected void init(V startNode) {
-        this.currentStartNode = startNode;
-    }
-
-    /**
      * Returns the outgoing edges of a node for directed graphs and all edges of
      * a node for undirected graphs. Used in Dijkstra.
      *
@@ -125,10 +112,14 @@ public abstract class GraphSearchAlgorithm<V extends VPred, E> {
      * @return The outgoing edges of the node.
      */
     public Set<E> outgoingEdgesOf(V node) {
-        if (graph instanceof DirectedGraph) {
-            return ((DirectedGraph) graph).outgoingEdgesOf(node);
+        return outgoingEdgesOf(graph, node);
+    }
+
+    public static Set outgoingEdgesOf(Graph g, Object node) {
+        if (g instanceof DirectedGraph) {
+            return ((DirectedGraph) g).outgoingEdgesOf(node);
         } else {
-            return graph.edgesOf(node);
+            return g.edgesOf(node);
         }
     }
 

--- a/src/main/java/org/javanetworkanalyzer/alg/GraphSearchAlgorithm.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/GraphSearchAlgorithm.java
@@ -25,6 +25,7 @@
 package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VPred;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.javanetworkanalyzer.model.TraversalGraph;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
@@ -42,7 +43,7 @@ import java.util.Set;
  * @param <E> Edges
  * @author Adam Gouge
  */
-public abstract class GraphSearchAlgorithm<V extends VPred, E>
+public abstract class GraphSearchAlgorithm<V extends VPred, E extends EdgeSPT>
         implements TraversalAlg<V, E> {
 
     /**
@@ -92,12 +93,14 @@ public abstract class GraphSearchAlgorithm<V extends VPred, E>
                 traversalGraph.addVertex(source);
                 traversalGraph.addVertex(target);
                 if (v.equals(source)) {
-                    traversalGraph.addEdge(target, source);
+                    traversalGraph.addEdge(target, source).setBaseGraphEdge(e);
                 } else if (v.equals(target)) {
-                    traversalGraph.addEdge(source, target);
+                    traversalGraph.addEdge(source, target).setBaseGraphEdge(e);
                 } else {
-                    System.out.println("equals neither");
+                    throw new IllegalStateException("A vertex has a predecessor " +
+                            "edge not ending on itself.");
                 }
+
             }
         }
 

--- a/src/main/java/org/javanetworkanalyzer/alg/TraversalAlg.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/TraversalAlg.java
@@ -1,0 +1,29 @@
+package org.javanetworkanalyzer.alg;
+
+import org.javanetworkanalyzer.data.VPred;
+import org.javanetworkanalyzer.model.TraversalGraph;
+
+/**
+ * Interface for algorithms that traverse a graph.
+ *
+ * @author Adam Gouge
+ */
+public interface TraversalAlg<V extends VPred, E> {
+
+    /**
+     * Performs the graph search algorithm from the given start node.
+     *
+     * @param startNode Start node
+     */
+    void calculate(V startNode);
+
+    /**
+     * Returns the SPT (BFS/Dijkstra) or traversal graph (DFS) from the last
+     * start node {@link #calculate} was called on. For BFS/Dijkstra, the
+     * shortest path "tree" we return may contain multiple shortest paths.
+     *
+     * @return The SPT/traversal graph from the last start node {@link #calculate}
+     *         was called on
+     */
+    TraversalGraph<V, E> reconstructTraversalGraph();
+}

--- a/src/main/java/org/javanetworkanalyzer/alg/TraversalAlg.java
+++ b/src/main/java/org/javanetworkanalyzer/alg/TraversalAlg.java
@@ -1,6 +1,7 @@
 package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VPred;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.javanetworkanalyzer.model.TraversalGraph;
 
 /**
@@ -8,7 +9,7 @@ import org.javanetworkanalyzer.model.TraversalGraph;
  *
  * @author Adam Gouge
  */
-public interface TraversalAlg<V extends VPred, E> {
+public interface TraversalAlg<V extends VPred, E extends EdgeSPT> {
 
     /**
      * Performs the graph search algorithm from the given start node.

--- a/src/main/java/org/javanetworkanalyzer/analyzers/AccessibilityAnalyzer.java
+++ b/src/main/java/org/javanetworkanalyzer/analyzers/AccessibilityAnalyzer.java
@@ -27,6 +27,7 @@ package org.javanetworkanalyzer.analyzers;
 import java.util.Set;
 import org.javanetworkanalyzer.alg.DijkstraForAccessibility;
 import org.javanetworkanalyzer.data.VAccess;
+import org.javanetworkanalyzer.model.EdgeSPT;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.EdgeReversedGraph;
@@ -37,7 +38,7 @@ import org.jgrapht.graph.EdgeReversedGraph;
  *
  * @author Adam Gouge
  */
-public class AccessibilityAnalyzer<E> extends GeneralizedGraphAnalyzer<VAccess, E> {
+public class AccessibilityAnalyzer<E extends EdgeSPT> extends GeneralizedGraphAnalyzer<VAccess, E> {
 
     /**
      * The set of destinations.

--- a/src/main/java/org/javanetworkanalyzer/analyzers/UnweightedGraphAnalyzer.java
+++ b/src/main/java/org/javanetworkanalyzer/analyzers/UnweightedGraphAnalyzer.java
@@ -25,8 +25,10 @@
 package org.javanetworkanalyzer.analyzers;
 
 import org.javanetworkanalyzer.alg.BFSForCentrality;
+import org.javanetworkanalyzer.alg.GraphSearchAlgorithm;
 import org.javanetworkanalyzer.data.VUCent;
 import org.javanetworkanalyzer.data.UnweightedPathLengthData;
+import org.javanetworkanalyzer.model.EdgeCent;
 import org.javanetworkanalyzer.progress.NullProgressMonitor;
 import org.javanetworkanalyzer.progress.ProgressMonitor;
 import java.lang.reflect.InvocationTargetException;
@@ -39,7 +41,7 @@ import org.jgrapht.Graph;
  *
  * @author Adam Gouge
  */
-public class UnweightedGraphAnalyzer<E>
+public class UnweightedGraphAnalyzer<E extends EdgeCent>
         extends GraphAnalyzer<VUCent, E, UnweightedPathLengthData> {
 
     private final BFSForCentrality<E> bfs;
@@ -81,17 +83,13 @@ public class UnweightedGraphAnalyzer<E>
      * also updates the predecessor sets.
      *
      * @param startNode          The start node.
-     * @param stack              The stack which will return nodes ordered by
-     *                           non-increasing distance from startNode.
-     * @param pathsFromStartNode Holds information about shortest path lengths
-     *                           from startNode to the other nodes in the
-     *                           network
+     *
      */
     @Override
-    protected UnweightedPathLengthData calculateShortestPathsFromNode(
+    protected BFSForCentrality<E> calculateShortestPathsFromNode(
             VUCent startNode) {
         bfs.calculate(startNode);
-        return bfs.getPaths();
+        return bfs;
     }
 
     @Override

--- a/src/main/java/org/javanetworkanalyzer/analyzers/WeightedGraphAnalyzer.java
+++ b/src/main/java/org/javanetworkanalyzer/analyzers/WeightedGraphAnalyzer.java
@@ -25,8 +25,10 @@
 package org.javanetworkanalyzer.analyzers;
 
 import org.javanetworkanalyzer.alg.DijkstraForCentrality;
+import org.javanetworkanalyzer.alg.GraphSearchAlgorithm;
 import org.javanetworkanalyzer.data.VWCent;
 import org.javanetworkanalyzer.data.WeightedPathLengthData;
+import org.javanetworkanalyzer.model.EdgeCent;
 import org.javanetworkanalyzer.progress.NullProgressMonitor;
 import org.javanetworkanalyzer.progress.ProgressMonitor;
 import java.lang.reflect.InvocationTargetException;
@@ -38,7 +40,7 @@ import org.jgrapht.WeightedGraph;
  *
  * @author Adam Gouge
  */
-public class WeightedGraphAnalyzer<E>
+public class WeightedGraphAnalyzer<E extends EdgeCent>
         extends GraphAnalyzer<VWCent, E, WeightedPathLengthData> {
 
     private final DijkstraForCentrality<E> dijkstra;
@@ -78,7 +80,7 @@ public class WeightedGraphAnalyzer<E>
      * {@inheritDoc}
      */
     @Override
-    protected WeightedPathLengthData calculateShortestPathsFromNode(
+    protected DijkstraForCentrality<E> calculateShortestPathsFromNode(
             VWCent startNode) {
         // Need to compute all shortest paths from s=startNode.
         //
@@ -95,7 +97,7 @@ public class WeightedGraphAnalyzer<E>
         // the nodes are popped in order of non-increasing distance from s.
         // This is IMPORTANT.
         dijkstra.calculate(startNode);
-        return dijkstra.getPaths();
+        return dijkstra;
     }
 
     @Override

--- a/src/main/java/org/javanetworkanalyzer/data/VPred.java
+++ b/src/main/java/org/javanetworkanalyzer/data/VPred.java
@@ -62,7 +62,7 @@ public interface VPred<V extends VPred, E> {
      *
      * @param pred Node to be added since it is a predecessor of this node
      */
-    public void addPredecessorEdge(E pred);
+    void addPredecessorEdge(E pred);
 
     /**
      * Clears the edge and vertex predecessors of this node.

--- a/src/main/java/org/javanetworkanalyzer/model/Edge.java
+++ b/src/main/java/org/javanetworkanalyzer/model/Edge.java
@@ -39,8 +39,9 @@ public class Edge extends DefaultWeightedEdge {
     /**
      * Sets the weight of this edge.
      */
-    public void setWeight(double newWeight) {
+    public Edge setWeight(double newWeight) {
         weight = newWeight;
+        return this;
     }
 
     @Override

--- a/src/main/java/org/javanetworkanalyzer/model/Edge.java
+++ b/src/main/java/org/javanetworkanalyzer/model/Edge.java
@@ -28,13 +28,15 @@ import org.jgrapht.WeightedGraph;
 import org.jgrapht.graph.DefaultWeightedEdge;
 
 /**
- * Empty class.
+ * Weighted edge for use in {@link TraversalGraph}.
  *
  * @author Adam Gouge
  */
-public class Edge extends DefaultWeightedEdge {
+public class Edge<E extends Edge<E>> extends DefaultWeightedEdge
+        implements EdgeSPT<E> {
 
     private double weight = WeightedGraph.DEFAULT_EDGE_WEIGHT;
+    private E baseGraphEdge;
 
     /**
      * Sets the weight of this edge.
@@ -47,5 +49,15 @@ public class Edge extends DefaultWeightedEdge {
     @Override
     protected double getWeight() {
         return weight;
+    }
+
+    @Override
+    public E getBaseGraphEdge() {
+        return baseGraphEdge;
+    }
+
+    @Override
+    public void setBaseGraphEdge(E edgeCent) {
+        baseGraphEdge = edgeCent;
     }
 }

--- a/src/main/java/org/javanetworkanalyzer/model/EdgeCent.java
+++ b/src/main/java/org/javanetworkanalyzer/model/EdgeCent.java
@@ -1,11 +1,11 @@
 package org.javanetworkanalyzer.model;
 
 /**
- * An Edge for calculating edge betweenness centrality.
+ * An {@link Edge} for calculating edge betweenness centrality.
  *
  * @author Adam Gouge
  */
-public class EdgeCent extends Edge {
+public class EdgeCent extends Edge<EdgeCent> {
 
     /**
      * Dependency of this node on any other vertex.

--- a/src/main/java/org/javanetworkanalyzer/model/EdgeCent.java
+++ b/src/main/java/org/javanetworkanalyzer/model/EdgeCent.java
@@ -1,0 +1,44 @@
+package org.javanetworkanalyzer.model;
+
+/**
+ * An Edge for calculating edge betweenness centrality.
+ *
+ * @author Adam Gouge
+ */
+public class EdgeCent extends Edge {
+
+    /**
+     * Dependency of this node on any other vertex.
+     */
+    protected double dependency = 0.0;
+    /**
+     * Betweenness value of this node.
+     */
+    private double betweenness = 0.0;
+
+    public double getDependency() {
+        return dependency;
+    }
+
+    public void accumulateDependency(double additionalDependency) {
+        dependency += additionalDependency;
+    }
+
+    public double getBetweenness() {
+        return betweenness;
+    }
+
+    public void accumulateBetweenness(double additionalBetweenness) {
+        setBetweenness(getBetweenness() + additionalBetweenness);
+    }
+
+    public void setBetweenness(double betweenness) {
+        this.betweenness = betweenness;
+    }
+
+    @Override
+    public EdgeCent setWeight(double newWeight) {
+        super.setWeight(newWeight);
+        return this;
+    }
+}

--- a/src/main/java/org/javanetworkanalyzer/model/EdgeSPT.java
+++ b/src/main/java/org/javanetworkanalyzer/model/EdgeSPT.java
@@ -1,0 +1,14 @@
+package org.javanetworkanalyzer.model;
+
+/**
+ * Interface for edges to be used in a
+ * {@link org.javanetworkanalyzer.alg.TraversalAlg}.
+ *
+ * @author Adam Gouge
+ */
+public interface EdgeSPT<E extends EdgeSPT> {
+
+    E getBaseGraphEdge();
+
+    void setBaseGraphEdge(E e);
+}

--- a/src/test/java/org/javanetworkanalyzer/alg/StrahlerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/alg/StrahlerTest.java
@@ -25,6 +25,7 @@
 package org.javanetworkanalyzer.alg;
 
 import org.javanetworkanalyzer.data.VStrahler;
+import org.javanetworkanalyzer.model.Edge;
 import org.javanetworkanalyzer.model.StrahlerTree;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
@@ -53,9 +54,9 @@ public class StrahlerTest {
     @Test
     public void testStrahler() {
 
-        StrahlerTree<DefaultEdge> tree = prepareTree();
+        StrahlerTree<Edge> tree = prepareTree();
 
-        new DFSForStrahler<DefaultEdge>(tree)
+        new DFSForStrahler<Edge>(tree)
                 .calculate(tree.getRootVertex());
 
         // We know what the answers should be.
@@ -84,10 +85,10 @@ public class StrahlerTest {
      *
      * @return A tree with root node 1.
      */
-    protected StrahlerTree<DefaultEdge> prepareTree() {
+    protected StrahlerTree<Edge> prepareTree() {
 
-        StrahlerTree<DefaultEdge> graph =
-                new StrahlerTree<DefaultEdge>(DefaultEdge.class);
+        StrahlerTree<Edge> graph =
+                new StrahlerTree<Edge>(Edge.class);
 
         graph.addEdge(1, 2);
         graph.addEdge(1, 3);

--- a/src/test/java/org/javanetworkanalyzer/analyzers/AccessibilityAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/AccessibilityAnalyzerTest.java
@@ -28,12 +28,7 @@ import java.util.HashSet;
 import java.util.Set;
 import org.javanetworkanalyzer.data.VAccess;
 import org.javanetworkanalyzer.graphcreators.CormenGraphPrep;
-import org.javanetworkanalyzer.model.DirectedG;
-import org.javanetworkanalyzer.model.DirectedWeightedPseudoG;
-import org.javanetworkanalyzer.model.Edge;
-import org.javanetworkanalyzer.model.KeyedGraph;
-import org.javanetworkanalyzer.model.UndirectedG;
-import org.javanetworkanalyzer.model.WeightedEdgeReversedG;
+import org.javanetworkanalyzer.model.*;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -49,7 +44,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
     @Test
     public void testD() throws Exception {
-        DirectedG<VAccess, Edge> g = directed();
+        DirectedG<VAccess, EdgeCent> g = directed();
         test(g);
         assertEquals(4, g.getVertex(1).getClosestDestinationId());
         assertEquals(1.0, g.getVertex(1).getDistanceToClosestDestination(),
@@ -70,7 +65,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
     @Test
     public void testR() throws Exception {
-        DirectedG<VAccess, Edge> g = reversed();
+        DirectedG<VAccess, EdgeCent> g = reversed();
         test(g);
         assertEquals(5, g.getVertex(1).getClosestDestinationId());
         assertEquals(1.0, g.getVertex(1).getDistanceToClosestDestination(),
@@ -95,7 +90,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
     @Test
     public void testU() throws Exception {
-        UndirectedG<VAccess, Edge> g = undirected();
+        UndirectedG<VAccess, EdgeCent> g = undirected();
         test(g);
         // The closest destination could be either 4 or 5.
         if (g.getVertex(1).getClosestDestinationId() != 4
@@ -124,7 +119,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
     @Test
     public void testWD() throws Exception {
-        DirectedWeightedPseudoG<VAccess, Edge> g = weightedDirected();
+        DirectedWeightedPseudoG<VAccess, EdgeCent> g = weightedDirected();
         test(g);
         assertEquals(4, g.getVertex(1).getClosestDestinationId());
         assertEquals(5.0, g.getVertex(1).getDistanceToClosestDestination(),
@@ -145,7 +140,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
     @Test
     public void testWR() throws Exception {
-        WeightedEdgeReversedG<VAccess, Edge> g = weightedReversed();
+        WeightedEdgeReversedG<VAccess, EdgeCent> g = weightedReversed();
         test(g);
         assertEquals(5, g.getVertex(1).getClosestDestinationId());
         assertEquals(7.0, g.getVertex(1).getDistanceToClosestDestination(),
@@ -166,7 +161,7 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
 
     @Test
     public void testWU() throws Exception {
-        UndirectedG<VAccess, Edge> g = weightedUndirected();
+        UndirectedG<VAccess, EdgeCent> g = weightedUndirected();
         test(g);
         assertEquals(4, g.getVertex(1).getClosestDestinationId());
         assertEquals(5.0, g.getVertex(1).getDistanceToClosestDestination(),
@@ -185,12 +180,12 @@ public class AccessibilityAnalyzerTest extends CormenGraphPrep {
                      TOLERANCE);
     }
 
-    public void test(KeyedGraph<VAccess, Edge> g) throws Exception {
+    public void test(KeyedGraph<VAccess, EdgeCent> g) throws Exception {
         // Prepare the destinations.
         Set<VAccess> destinations = new HashSet<VAccess>();
         destinations.add(g.getVertex(5));
         destinations.add(g.getVertex(4));
         // Do accessibility analysis.
-        new AccessibilityAnalyzer<Edge>(g, destinations).compute();
+        new AccessibilityAnalyzer<EdgeCent>(g, destinations).compute();
     }
 }

--- a/src/test/java/org/javanetworkanalyzer/analyzers/CentralityTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/CentralityTest.java
@@ -24,6 +24,7 @@
  */
 package org.javanetworkanalyzer.analyzers;
 
+import junit.framework.TestCase;
 import org.javanetworkanalyzer.data.VCent;
 import org.javanetworkanalyzer.model.Edge;
 import org.jgrapht.Graph;

--- a/src/test/java/org/javanetworkanalyzer/analyzers/GraphAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/GraphAnalyzerTest.java
@@ -28,15 +28,13 @@ import static org.javanetworkanalyzer.analyzers.CentralityTest.TOLERANCE;
 import org.javanetworkanalyzer.data.VCent;
 import org.javanetworkanalyzer.data.VUCent;
 import org.javanetworkanalyzer.data.VWCent;
-import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.model.*;
 import org.javanetworkanalyzer.graphcreators.GraphCreator;
 import org.javanetworkanalyzer.graphcreators.WeightedGraphCreator;
-import org.javanetworkanalyzer.model.DirectedG;
-import org.javanetworkanalyzer.model.KeyedGraph;
-import org.javanetworkanalyzer.model.UndirectedG;
-import org.javanetworkanalyzer.model.WeightedKeyedGraph;
 import org.javanetworkanalyzer.progress.ProgressMonitor;
 import static org.junit.Assert.assertEquals;
+
+import org.jgrapht.graph.DefaultWeightedEdge;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,8 +67,8 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    protected KeyedGraph<VUCent, Edge> doUnweightedAnalysis(
-            KeyedGraph<VUCent, Edge> graph,
+    protected KeyedGraph<VUCent, EdgeCent> doUnweightedAnalysis(
+            KeyedGraph<VUCent, EdgeCent> graph,
             String orientation) {
         try {
             doAnalysis(new UnweightedGraphAnalyzer(graph, progressMonitor()),
@@ -93,8 +91,8 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    protected WeightedKeyedGraph<VWCent, Edge> doWeightedAnalysis(
-            WeightedKeyedGraph<VWCent, Edge> graph,
+    protected WeightedKeyedGraph<VWCent, EdgeCent> doWeightedAnalysis(
+            WeightedKeyedGraph<VWCent, EdgeCent> graph,
             String orientation) {
         try {
             doAnalysis(new WeightedGraphAnalyzer(graph, progressMonitor()),
@@ -115,7 +113,7 @@ public abstract class GraphAnalyzerTest
      * @param analysisType Describes the type of analysis.
      */
     private void doAnalysis(
-            GraphAnalyzer<?, Edge, ?> analyzer,
+            GraphAnalyzer<?, ?, ?> analyzer,
             String analysisType) {
         long start = System.currentTimeMillis();
         try {
@@ -131,7 +129,7 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    public DirectedG<VUCent, Edge> unweightedDirectedAnalysis() {
+    public DirectedG<VUCent, EdgeCent> unweightedDirectedAnalysis() {
         try {
             return (DirectedG) doUnweightedAnalysis(unweightedGraph(
                     GraphCreator.DIRECTED), DIRECTED);
@@ -146,7 +144,7 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    public DirectedG<VUCent, Edge> unweightedReversedAnalysis() {
+    public DirectedG<VUCent, EdgeCent> unweightedReversedAnalysis() {
         try {
             return (DirectedG) doUnweightedAnalysis(unweightedGraph(
                     GraphCreator.REVERSED), REVERSED);
@@ -161,7 +159,7 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    public UndirectedG<VUCent, Edge> unweightedUndirectedAnalysis() {
+    public UndirectedG<VUCent, EdgeCent> unweightedUndirectedAnalysis() {
         try {
             return (UndirectedG) doUnweightedAnalysis(unweightedGraph(
                     GraphCreator.UNDIRECTED), UNDIRECTED);
@@ -176,7 +174,7 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    public DirectedG<VWCent, Edge> weightedDirectedAnalysis() {
+    public DirectedG<VWCent, EdgeCent> weightedDirectedAnalysis() {
         try {
             return (DirectedG) doWeightedAnalysis(weightedGraph(
                     GraphCreator.DIRECTED), DIRECTED);
@@ -191,7 +189,7 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    public DirectedG<VWCent, Edge> weightedReversedAnalysis() {
+    public DirectedG<VWCent, EdgeCent> weightedReversedAnalysis() {
         try {
             return (DirectedG) doWeightedAnalysis(weightedGraph(
                     GraphCreator.REVERSED), REVERSED);
@@ -206,7 +204,7 @@ public abstract class GraphAnalyzerTest
      *
      * @return The graph.
      */
-    public UndirectedG<VWCent, Edge> weightedUndirectedAnalysis() {
+    public UndirectedG<VWCent, EdgeCent> weightedUndirectedAnalysis() {
         try {
             return (UndirectedG) doWeightedAnalysis(weightedGraph(
                     GraphCreator.UNDIRECTED), UNDIRECTED);
@@ -242,13 +240,13 @@ public abstract class GraphAnalyzerTest
      * @return The graph.
      *
      */
-    protected KeyedGraph<VUCent, Edge> unweightedGraph(
+    protected KeyedGraph<VUCent, EdgeCent> unweightedGraph(
             int orientation) {
         try {
             return new GraphCreator(getFilename(),
                                     orientation,
                                     VUCent.class,
-                                    Edge.class).loadGraph();
+                                    EdgeCent.class).loadGraph();
         } catch (Exception ex) {
         }
         return null;
@@ -263,13 +261,13 @@ public abstract class GraphAnalyzerTest
      * @return The graph.
      *
      */
-    protected WeightedKeyedGraph<VWCent, Edge> weightedGraph(
+    protected WeightedKeyedGraph<VWCent, EdgeCent> weightedGraph(
             int orientation) {
         try {
             return new WeightedGraphCreator(getFilename(),
                                             orientation,
                                             VWCent.class,
-                                            Edge.class,
+                                            EdgeCent.class,
                                             getWeightColumnName()).loadGraph();
         } catch (Exception ex) {
         }
@@ -285,7 +283,7 @@ public abstract class GraphAnalyzerTest
      */
     protected void checkBetweenness(
             double[] expectedBetweenness,
-            KeyedGraph<? extends VCent, Edge> graph) {
+            KeyedGraph<? extends VCent, ? extends DefaultWeightedEdge> graph) {
         if (graph != null) {
             VCent vertex;
             for (int i = 0; i < getNumberOfNodes(); i++) {
@@ -312,7 +310,7 @@ public abstract class GraphAnalyzerTest
      */
     protected void checkCloseness(
             double[] expectedCloseness,
-            KeyedGraph<? extends VCent, Edge> graph) {
+            KeyedGraph<? extends VCent, ? extends DefaultWeightedEdge> graph) {
         if (graph != null) {
             VCent vertex;
             for (int i = 0; i < getNumberOfNodes(); i++) {

--- a/src/test/java/org/javanetworkanalyzer/analyzers/ManuallyCreatedGraphAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/ManuallyCreatedGraphAnalyzerTest.java
@@ -27,19 +27,9 @@ package org.javanetworkanalyzer.analyzers;
 import org.javanetworkanalyzer.data.VCent;
 import org.javanetworkanalyzer.data.VUCent;
 import org.javanetworkanalyzer.data.VWCent;
-import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.model.*;
 import org.javanetworkanalyzer.graphcreators.GraphCreator;
 import static org.javanetworkanalyzer.graphcreators.GraphCreator.UNDIRECTED;
-import org.javanetworkanalyzer.model.DirectedG;
-import org.javanetworkanalyzer.model.DirectedPseudoG;
-import org.javanetworkanalyzer.model.DirectedWeightedPseudoG;
-import org.javanetworkanalyzer.model.EdgeReversedG;
-import org.javanetworkanalyzer.model.KeyedGraph;
-import org.javanetworkanalyzer.model.PseudoG;
-import org.javanetworkanalyzer.model.UndirectedG;
-import org.javanetworkanalyzer.model.WeightedEdgeReversedG;
-import org.javanetworkanalyzer.model.WeightedKeyedGraph;
-import org.javanetworkanalyzer.model.WeightedPseudoG;
 
 /**
  * Test helper for manually-entered graphs.
@@ -57,7 +47,7 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      * @param graph The graph.
      */
     protected void addVertices(
-            KeyedGraph<? extends VCent, Edge> graph) {
+            KeyedGraph<? extends VCent, EdgeCent> graph) {
         for (int i = 1; i <= getNumberOfNodes(); i++) {
             graph.addVertex(i);
         }
@@ -69,7 +59,7 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      * @param graph The graph.
      */
     protected abstract void addEdges(
-            KeyedGraph<? extends VCent, Edge> graph);
+            KeyedGraph<? extends VCent, EdgeCent> graph);
 
     /**
      * Manually adds weighted edges to the graph.
@@ -77,7 +67,7 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      * @param graph The graph.
      */
     protected abstract void addWeightedEdges(
-            WeightedKeyedGraph<? extends VCent, Edge> graph);
+            WeightedKeyedGraph<? extends VCent, EdgeCent> graph);
 
     /**
      * Loads an unweighted graph with the given orientation.
@@ -88,9 +78,9 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      *
      */
     @Override
-    protected KeyedGraph<VUCent, Edge> unweightedGraph(
+    protected KeyedGraph<VUCent, EdgeCent> unweightedGraph(
             int orientation) {
-        KeyedGraph<VUCent, Edge> graph;
+        KeyedGraph<VUCent, EdgeCent> graph;
         if (orientation == GraphCreator.DIRECTED) {
             graph = unweightedDirectedGraph();
         } else if (orientation == GraphCreator.REVERSED) {
@@ -112,9 +102,9 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      *
      */
     @Override
-    protected WeightedKeyedGraph<VWCent, Edge> weightedGraph(
+    protected WeightedKeyedGraph<VWCent, EdgeCent> weightedGraph(
             int orientation) {
-        KeyedGraph<VWCent, Edge> graph;
+        KeyedGraph<VWCent, EdgeCent> graph;
         if (orientation == GraphCreator.DIRECTED) {
             graph = weightedDirectedGraph();
         } else if (orientation == GraphCreator.REVERSED) {
@@ -130,8 +120,8 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
     /**
      * Creates an unweighted directed graph.
      */
-    private DirectedG<VUCent, Edge> unweightedDirectedGraph() {
-        KeyedGraph<? extends VCent, Edge> graph = null;
+    private DirectedG<VUCent, EdgeCent> unweightedDirectedGraph() {
+        KeyedGraph<? extends VCent, EdgeCent> graph = null;
         try {
             graph = initializeUnweightedGraph(GraphCreator.DIRECTED);
             addVertices(graph);
@@ -144,10 +134,10 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
     /**
      * Creates an unweighted edge reversed graph.
      */
-    private DirectedG<VUCent, Edge> unweightedReversedGraph() {
-        EdgeReversedG<VUCent, Edge> graph = null;
+    private DirectedG<VUCent, EdgeCent> unweightedReversedGraph() {
+        EdgeReversedG<VUCent, EdgeCent> graph = null;
         try {
-            graph = new EdgeReversedG<VUCent, Edge>(
+            graph = new EdgeReversedG<VUCent, EdgeCent>(
                     unweightedDirectedGraph());
         } catch (NoSuchMethodException ex) {
         }
@@ -157,8 +147,8 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
     /**
      * Creates an unweighted undirected graph.
      */
-    private UndirectedG<VUCent, Edge> unweightedUndirectedGraph() {
-        KeyedGraph<? extends VCent, Edge> graph = null;
+    private UndirectedG<VUCent, EdgeCent> unweightedUndirectedGraph() {
+        KeyedGraph<? extends VCent, EdgeCent> graph = null;
         try {
             graph = initializeUnweightedGraph(GraphCreator.UNDIRECTED);
             addVertices(graph);
@@ -171,8 +161,8 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
     /**
      * Creates a weighted directed graph.
      */
-    private DirectedG<VWCent, Edge> weightedDirectedGraph() {
-        WeightedKeyedGraph<? extends VCent, Edge> graph = null;
+    private DirectedG<VWCent, EdgeCent> weightedDirectedGraph() {
+        WeightedKeyedGraph<? extends VCent, EdgeCent> graph = null;
         try {
             graph = initializeWeightedGraph(getWeightColumnName(),
                                             GraphCreator.DIRECTED);
@@ -186,10 +176,10 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
     /**
      * Creates a weighted edge reversed graph.
      */
-    private DirectedG<VWCent, Edge> weightedReversedGraph() {
-        WeightedKeyedGraph<VWCent, Edge> graph = null;
+    private DirectedG<VWCent, EdgeCent> weightedReversedGraph() {
+        WeightedKeyedGraph<VWCent, EdgeCent> graph = null;
         try {
-            graph = new WeightedEdgeReversedG<VWCent, Edge>(
+            graph = new WeightedEdgeReversedG<VWCent, EdgeCent>(
                     weightedDirectedGraph());
         } catch (NoSuchMethodException ex) {
         }
@@ -199,8 +189,8 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
     /**
      * Creates a weighted undirected graph.
      */
-    private UndirectedG<VWCent, Edge> weightedUndirectedGraph() {
-        WeightedKeyedGraph<? extends VCent, Edge> graph = null;
+    private UndirectedG<VWCent, EdgeCent> weightedUndirectedGraph() {
+        WeightedKeyedGraph<? extends VCent, EdgeCent> graph = null;
         try {
             graph = initializeWeightedGraph(getWeightColumnName(),
                                             GraphCreator.UNDIRECTED);
@@ -219,14 +209,14 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      *
      * @return The newly initialized graph.
      */
-    private KeyedGraph<? extends VCent, Edge> initializeUnweightedGraph(
+    private KeyedGraph<? extends VCent, EdgeCent> initializeUnweightedGraph(
             int orientation) throws NoSuchMethodException {
         if (orientation != UNDIRECTED) {
-            return new DirectedPseudoG<VUCent, Edge>(
-                    VUCent.class, Edge.class);
+            return new DirectedPseudoG<VUCent, EdgeCent>(
+                    VUCent.class, EdgeCent.class);
         } else {
-            return new PseudoG<VUCent, Edge>(
-                    VUCent.class, Edge.class);
+            return new PseudoG<VUCent, EdgeCent>(
+                    VUCent.class, EdgeCent.class);
         }
     }
 
@@ -239,15 +229,15 @@ public abstract class ManuallyCreatedGraphAnalyzerTest extends GraphAnalyzerTest
      *
      * @return The newly initialized graph.
      */
-    private WeightedKeyedGraph<? extends VCent, Edge> initializeWeightedGraph(
+    private WeightedKeyedGraph<? extends VCent, EdgeCent> initializeWeightedGraph(
             String weightColumnName,
             int orientation) throws NoSuchMethodException {
         if (orientation != UNDIRECTED) {
-            return new DirectedWeightedPseudoG<VWCent, Edge>(
-                    VWCent.class, Edge.class);
+            return new DirectedWeightedPseudoG<VWCent, EdgeCent>(
+                    VWCent.class, EdgeCent.class);
         } else {
-            return new WeightedPseudoG<VWCent, Edge>(
-                    VWCent.class, Edge.class);
+            return new WeightedPseudoG<VWCent, EdgeCent>(
+                    VWCent.class, EdgeCent.class);
         }
     }
 

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
@@ -123,6 +123,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.66666666667
             }, graph);
         }
+        assertEquals(4, e1.getBetweenness(), TOLERANCE);
+        assertEquals(5, e2.getBetweenness(), TOLERANCE);
+        assertEquals(8, e3.getBetweenness(), TOLERANCE);
+        assertEquals(2, e4.getBetweenness(), TOLERANCE);
+        assertEquals(1, e5.getBetweenness(), TOLERANCE);
+        assertEquals(3, e6.getBetweenness(), TOLERANCE);
+        assertEquals(2, e7.getBetweenness(), TOLERANCE);
+        assertEquals(5, e8.getBetweenness(), TOLERANCE);
+        assertEquals(1, e9.getBetweenness(), TOLERANCE);
+        assertEquals(4, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -145,6 +155,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.66666666667
             }, graph);
         }
+        assertEquals(4, e1.getBetweenness(), TOLERANCE);
+        assertEquals(5, e2.getBetweenness(), TOLERANCE);
+        assertEquals(9, e3.getBetweenness(), TOLERANCE);
+        assertEquals(3, e4.getBetweenness(), TOLERANCE);
+        assertEquals(1, e5.getBetweenness(), TOLERANCE);
+        assertEquals(4, e6.getBetweenness(), TOLERANCE);
+        assertEquals(2, e7.getBetweenness(), TOLERANCE);
+        assertEquals(6, e8.getBetweenness(), TOLERANCE);
+        assertEquals(1, e9.getBetweenness(), TOLERANCE);
+        assertEquals(5, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -167,6 +187,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.80000000000
             }, graph);
         }
+        assertEquals(6, e1.getBetweenness(), TOLERANCE);
+        assertEquals(4, e2.getBetweenness(), TOLERANCE);
+        assertEquals(6, e3.getBetweenness(), TOLERANCE);
+        assertEquals(3, e4.getBetweenness(), TOLERANCE);
+        assertEquals(0, e5.getBetweenness(), TOLERANCE);
+        assertEquals(6, e6.getBetweenness(), TOLERANCE);
+        assertEquals(4, e7.getBetweenness(), TOLERANCE);
+        assertEquals(4, e8.getBetweenness(), TOLERANCE);
+        assertEquals(0, e9.getBetweenness(), TOLERANCE);
+        assertEquals(4, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -190,17 +220,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.10000000000
             }, graph);
         }
-
-        assertEquals(0, e1.getBetweenness(), 0);
-        assertEquals(8, e2.getBetweenness(), 0);
-        assertEquals(8, e3.getBetweenness(), 0);
-        assertEquals(3, e4.getBetweenness(), 0);
-        assertEquals(6, e5.getBetweenness(), 0);
-        assertEquals(3, e6.getBetweenness(), 0);
-        assertEquals(0, e7.getBetweenness(), 0);
-        assertEquals(4, e8.getBetweenness(), 0);
-        assertEquals(1, e9.getBetweenness(), 0);
-        assertEquals(5, e10.getBetweenness(), 0);
+        assertEquals(0, e1.getBetweenness(), TOLERANCE);
+        assertEquals(8, e2.getBetweenness(), TOLERANCE);
+        assertEquals(8, e3.getBetweenness(), TOLERANCE);
+        assertEquals(3, e4.getBetweenness(), TOLERANCE);
+        assertEquals(6, e5.getBetweenness(), TOLERANCE);
+        assertEquals(3, e6.getBetweenness(), TOLERANCE);
+        assertEquals(0, e7.getBetweenness(), TOLERANCE);
+        assertEquals(4, e8.getBetweenness(), TOLERANCE);
+        assertEquals(1, e9.getBetweenness(), TOLERANCE);
+        assertEquals(5, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -223,6 +252,18 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.23529411765
             }, graph);
         }
+        // Note: These happen to be the same results as in weightedDirectedTest
+        // but this is not always true.
+        assertEquals(0, e1.getBetweenness(), TOLERANCE);
+        assertEquals(8, e2.getBetweenness(), TOLERANCE);
+        assertEquals(8, e3.getBetweenness(), TOLERANCE);
+        assertEquals(3, e4.getBetweenness(), TOLERANCE);
+        assertEquals(6, e5.getBetweenness(), TOLERANCE);
+        assertEquals(3, e6.getBetweenness(), TOLERANCE);
+        assertEquals(0, e7.getBetweenness(), TOLERANCE);
+        assertEquals(4, e8.getBetweenness(), TOLERANCE);
+        assertEquals(1, e9.getBetweenness(), TOLERANCE);
+        assertEquals(5, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -245,6 +286,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.23529411765
             }, graph);
         }
+        assertEquals(0, e1.getBetweenness(), TOLERANCE);
+        assertEquals(8, e2.getBetweenness(), TOLERANCE);
+        assertEquals(2, e3.getBetweenness(), TOLERANCE);
+        assertEquals(10, e4.getBetweenness(), TOLERANCE);
+        assertEquals(0, e5.getBetweenness(), TOLERANCE);
+        assertEquals(6, e6.getBetweenness(), TOLERANCE);
+        assertEquals(0, e7.getBetweenness(), TOLERANCE);
+        assertEquals(2, e8.getBetweenness(), TOLERANCE);
+        assertEquals(0, e9.getBetweenness(), TOLERANCE);
+        assertEquals(6, e10.getBetweenness(), TOLERANCE);
     }
 
     @Override

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
@@ -123,16 +123,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.66666666667
             }, graph);
         }
-        assertEquals(4, e1.getBetweenness(), TOLERANCE);
-        assertEquals(5, e2.getBetweenness(), TOLERANCE);
-        assertEquals(8, e3.getBetweenness(), TOLERANCE);
-        assertEquals(2, e4.getBetweenness(), TOLERANCE);
-        assertEquals(1, e5.getBetweenness(), TOLERANCE);
-        assertEquals(3, e6.getBetweenness(), TOLERANCE);
-        assertEquals(2, e7.getBetweenness(), TOLERANCE);
-        assertEquals(5, e8.getBetweenness(), TOLERANCE);
-        assertEquals(1, e9.getBetweenness(), TOLERANCE);
-        assertEquals(4, e10.getBetweenness(), TOLERANCE);
+        assertEquals(((7.0 / 2) - 1) / (8 - 1), e1.getBetweenness(), TOLERANCE);
+        assertEquals(((9.0 / 2) - 1) / (8 - 1), e2.getBetweenness(), TOLERANCE);
+        assertEquals((8.0 - 1) / (8 - 1), e3.getBetweenness(), TOLERANCE);
+        assertEquals((2.0 - 1) / (8 - 1), e4.getBetweenness(), TOLERANCE);
+        assertEquals((1.0 - 1) / (8 - 1), e5.getBetweenness(), TOLERANCE);
+        assertEquals(((5.0 / 2) - 1) / (8 - 1), e6.getBetweenness(), TOLERANCE);
+        assertEquals(((3.0 / 2) - 1) / (8 - 1), e7.getBetweenness(), TOLERANCE);
+        assertEquals((5.0 - 1) / (8 - 1), e8.getBetweenness(), TOLERANCE);
+        assertEquals((1.0 - 1) / (8 - 1), e9.getBetweenness(), TOLERANCE);
+        assertEquals((4.0 - 1) / (8 - 1), e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -155,16 +155,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.66666666667
             }, graph);
         }
-        assertEquals(4, e1.getBetweenness(), TOLERANCE);
-        assertEquals(5, e2.getBetweenness(), TOLERANCE);
-        assertEquals(9, e3.getBetweenness(), TOLERANCE);
-        assertEquals(3, e4.getBetweenness(), TOLERANCE);
-        assertEquals(1, e5.getBetweenness(), TOLERANCE);
-        assertEquals(4, e6.getBetweenness(), TOLERANCE);
-        assertEquals(2, e7.getBetweenness(), TOLERANCE);
-        assertEquals(6, e8.getBetweenness(), TOLERANCE);
-        assertEquals(1, e9.getBetweenness(), TOLERANCE);
-        assertEquals(5, e10.getBetweenness(), TOLERANCE);
+//        assertEquals(4.0 / 9, e1.getBetweenness(), TOLERANCE);
+//        assertEquals(5.0 / 9, e2.getBetweenness(), TOLERANCE);
+//        assertEquals(9.0 / 9, e3.getBetweenness(), TOLERANCE);
+//        assertEquals(3.0 / 9, e4.getBetweenness(), TOLERANCE);
+//        assertEquals(1.0 / 9, e5.getBetweenness(), TOLERANCE);
+//        assertEquals(4.0 / 9, e6.getBetweenness(), TOLERANCE);
+//        assertEquals(2.0 / 9, e7.getBetweenness(), TOLERANCE);
+//        assertEquals(6.0 / 9, e8.getBetweenness(), TOLERANCE);
+//        assertEquals(1.0 / 9, e9.getBetweenness(), TOLERANCE);
+//        assertEquals(5.0 / 9, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -187,16 +187,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.80000000000
             }, graph);
         }
-        assertEquals(6, e1.getBetweenness(), TOLERANCE);
-        assertEquals(4, e2.getBetweenness(), TOLERANCE);
-        assertEquals(6, e3.getBetweenness(), TOLERANCE);
-        assertEquals(3, e4.getBetweenness(), TOLERANCE);
-        assertEquals(0, e5.getBetweenness(), TOLERANCE);
-        assertEquals(6, e6.getBetweenness(), TOLERANCE);
-        assertEquals(4, e7.getBetweenness(), TOLERANCE);
-        assertEquals(4, e8.getBetweenness(), TOLERANCE);
-        assertEquals(0, e9.getBetweenness(), TOLERANCE);
-        assertEquals(4, e10.getBetweenness(), TOLERANCE);
+//        assertEquals(6.0 / 6, e1.getBetweenness(), TOLERANCE);
+//        assertEquals(4.0 / 6, e2.getBetweenness(), TOLERANCE);
+//        assertEquals(6.0 / 6, e3.getBetweenness(), TOLERANCE);
+//        assertEquals(3.0 / 6, e4.getBetweenness(), TOLERANCE);
+//        assertEquals(0.0 / 6, e5.getBetweenness(), TOLERANCE);
+//        assertEquals(6.0 / 6, e6.getBetweenness(), TOLERANCE);
+//        assertEquals(4.0 / 6, e7.getBetweenness(), TOLERANCE);
+//        assertEquals(4.0 / 6, e8.getBetweenness(), TOLERANCE);
+//        assertEquals(0.0 / 6, e9.getBetweenness(), TOLERANCE);
+//        assertEquals(4.0 / 6, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -220,16 +220,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.10000000000
             }, graph);
         }
-        assertEquals(0, e1.getBetweenness(), TOLERANCE);
-        assertEquals(8, e2.getBetweenness(), TOLERANCE);
-        assertEquals(8, e3.getBetweenness(), TOLERANCE);
-        assertEquals(3, e4.getBetweenness(), TOLERANCE);
-        assertEquals(6, e5.getBetweenness(), TOLERANCE);
-        assertEquals(3, e6.getBetweenness(), TOLERANCE);
-        assertEquals(0, e7.getBetweenness(), TOLERANCE);
-        assertEquals(4, e8.getBetweenness(), TOLERANCE);
-        assertEquals(1, e9.getBetweenness(), TOLERANCE);
-        assertEquals(5, e10.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 8, e1.getBetweenness(), TOLERANCE);
+        assertEquals(8.0 / 8, e2.getBetweenness(), TOLERANCE);
+        assertEquals(8.0 / 8, e3.getBetweenness(), TOLERANCE);
+        assertEquals(3.0 / 8, e4.getBetweenness(), TOLERANCE);
+        assertEquals(6.0 / 8, e5.getBetweenness(), TOLERANCE);
+        assertEquals(3.0 / 8, e6.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 8, e7.getBetweenness(), TOLERANCE);
+        assertEquals(4.0 / 8, e8.getBetweenness(), TOLERANCE);
+        assertEquals(1.0 / 8, e9.getBetweenness(), TOLERANCE);
+        assertEquals(5.0 / 8, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -254,16 +254,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
         }
         // Note: These happen to be the same results as in weightedDirectedTest
         // but this is not always true.
-        assertEquals(0, e1.getBetweenness(), TOLERANCE);
-        assertEquals(8, e2.getBetweenness(), TOLERANCE);
-        assertEquals(8, e3.getBetweenness(), TOLERANCE);
-        assertEquals(3, e4.getBetweenness(), TOLERANCE);
-        assertEquals(6, e5.getBetweenness(), TOLERANCE);
-        assertEquals(3, e6.getBetweenness(), TOLERANCE);
-        assertEquals(0, e7.getBetweenness(), TOLERANCE);
-        assertEquals(4, e8.getBetweenness(), TOLERANCE);
-        assertEquals(1, e9.getBetweenness(), TOLERANCE);
-        assertEquals(5, e10.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 8, e1.getBetweenness(), TOLERANCE);
+        assertEquals(8.0 / 8, e2.getBetweenness(), TOLERANCE);
+        assertEquals(8.0 / 8, e3.getBetweenness(), TOLERANCE);
+        assertEquals(3.0 / 8, e4.getBetweenness(), TOLERANCE);
+        assertEquals(6.0 / 8, e5.getBetweenness(), TOLERANCE);
+        assertEquals(3.0 / 8, e6.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 8, e7.getBetweenness(), TOLERANCE);
+        assertEquals(4.0 / 8, e8.getBetweenness(), TOLERANCE);
+        assertEquals(1.0 / 8, e9.getBetweenness(), TOLERANCE);
+        assertEquals(5.0 / 8, e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -286,16 +286,16 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.23529411765
             }, graph);
         }
-        assertEquals(0, e1.getBetweenness(), TOLERANCE);
-        assertEquals(8, e2.getBetweenness(), TOLERANCE);
-        assertEquals(2, e3.getBetweenness(), TOLERANCE);
-        assertEquals(10, e4.getBetweenness(), TOLERANCE);
-        assertEquals(0, e5.getBetweenness(), TOLERANCE);
-        assertEquals(6, e6.getBetweenness(), TOLERANCE);
-        assertEquals(0, e7.getBetweenness(), TOLERANCE);
-        assertEquals(2, e8.getBetweenness(), TOLERANCE);
-        assertEquals(0, e9.getBetweenness(), TOLERANCE);
-        assertEquals(6, e10.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 10, e1.getBetweenness(), TOLERANCE);
+        assertEquals(7.0 / 10, e2.getBetweenness(), TOLERANCE);
+        assertEquals(1.0 / 10, e3.getBetweenness(), TOLERANCE);
+        assertEquals(10.0 / 10, e4.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 10, e5.getBetweenness(), TOLERANCE);
+        assertEquals(6.0 / 10, e6.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 10, e7.getBetweenness(), TOLERANCE);
+        assertEquals(2.0 / 10, e8.getBetweenness(), TOLERANCE);
+        assertEquals(0.0 / 10, e9.getBetweenness(), TOLERANCE);
+        assertEquals(5.0 / 10, e10.getBetweenness(), TOLERANCE);
     }
 
     @Override

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
@@ -73,6 +73,8 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
     private EdgeCent e8;
     private EdgeCent e9;
     private EdgeCent e10;
+    private double minEdgeBetw;
+    private double maxEdgeBetw;
 
     @Override
     protected void addEdges(
@@ -123,16 +125,18 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.66666666667
             }, graph);
         }
-        assertEquals(((7.0 / 2) - 1) / (8 - 1), e1.getBetweenness(), TOLERANCE);
-        assertEquals(((9.0 / 2) - 1) / (8 - 1), e2.getBetweenness(), TOLERANCE);
-        assertEquals((8.0 - 1) / (8 - 1), e3.getBetweenness(), TOLERANCE);
-        assertEquals((2.0 - 1) / (8 - 1), e4.getBetweenness(), TOLERANCE);
-        assertEquals((1.0 - 1) / (8 - 1), e5.getBetweenness(), TOLERANCE);
-        assertEquals(((5.0 / 2) - 1) / (8 - 1), e6.getBetweenness(), TOLERANCE);
-        assertEquals(((3.0 / 2) - 1) / (8 - 1), e7.getBetweenness(), TOLERANCE);
-        assertEquals((5.0 - 1) / (8 - 1), e8.getBetweenness(), TOLERANCE);
-        assertEquals((1.0 - 1) / (8 - 1), e9.getBetweenness(), TOLERANCE);
-        assertEquals((4.0 - 1) / (8 - 1), e10.getBetweenness(), TOLERANCE);
+        minEdgeBetw = 1.0;
+        maxEdgeBetw = 8.0;
+        assertEquals((3.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e1.getBetweenness(), TOLERANCE);
+        assertEquals((4.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e2.getBetweenness(), TOLERANCE);
+        assertEquals((8.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e3.getBetweenness(), TOLERANCE);
+        assertEquals((2.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e4.getBetweenness(), TOLERANCE);
+        assertEquals((1.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e5.getBetweenness(), TOLERANCE);
+        assertEquals((2.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e6.getBetweenness(), TOLERANCE);
+        assertEquals((1.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e7.getBetweenness(), TOLERANCE);
+        assertEquals((5.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e8.getBetweenness(), TOLERANCE);
+        assertEquals((1.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e9.getBetweenness(), TOLERANCE);
+        assertEquals((4.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -155,16 +159,18 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.66666666667
             }, graph);
         }
-//        assertEquals(4.0 / 9, e1.getBetweenness(), TOLERANCE);
-//        assertEquals(5.0 / 9, e2.getBetweenness(), TOLERANCE);
-//        assertEquals(9.0 / 9, e3.getBetweenness(), TOLERANCE);
-//        assertEquals(3.0 / 9, e4.getBetweenness(), TOLERANCE);
-//        assertEquals(1.0 / 9, e5.getBetweenness(), TOLERANCE);
-//        assertEquals(4.0 / 9, e6.getBetweenness(), TOLERANCE);
-//        assertEquals(2.0 / 9, e7.getBetweenness(), TOLERANCE);
-//        assertEquals(6.0 / 9, e8.getBetweenness(), TOLERANCE);
-//        assertEquals(1.0 / 9, e9.getBetweenness(), TOLERANCE);
-//        assertEquals(5.0 / 9, e10.getBetweenness(), TOLERANCE);
+        minEdgeBetw = 1.0;
+        maxEdgeBetw = 8.0;
+        assertEquals((3.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e1.getBetweenness(), TOLERANCE);
+        assertEquals((4.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e2.getBetweenness(), TOLERANCE);
+        assertEquals((8.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e3.getBetweenness(), TOLERANCE);
+        assertEquals((2.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e4.getBetweenness(), TOLERANCE);
+        assertEquals((1.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e5.getBetweenness(), TOLERANCE);
+        assertEquals((2.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e6.getBetweenness(), TOLERANCE);
+        assertEquals((1.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e7.getBetweenness(), TOLERANCE);
+        assertEquals((5.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e8.getBetweenness(), TOLERANCE);
+        assertEquals((1.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e9.getBetweenness(), TOLERANCE);
+        assertEquals((4.0 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -187,16 +193,18 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.80000000000
             }, graph);
         }
-//        assertEquals(6.0 / 6, e1.getBetweenness(), TOLERANCE);
-//        assertEquals(4.0 / 6, e2.getBetweenness(), TOLERANCE);
-//        assertEquals(6.0 / 6, e3.getBetweenness(), TOLERANCE);
-//        assertEquals(3.0 / 6, e4.getBetweenness(), TOLERANCE);
-//        assertEquals(0.0 / 6, e5.getBetweenness(), TOLERANCE);
-//        assertEquals(6.0 / 6, e6.getBetweenness(), TOLERANCE);
-//        assertEquals(4.0 / 6, e7.getBetweenness(), TOLERANCE);
-//        assertEquals(4.0 / 6, e8.getBetweenness(), TOLERANCE);
-//        assertEquals(0.0 / 6, e9.getBetweenness(), TOLERANCE);
-//        assertEquals(4.0 / 6, e10.getBetweenness(), TOLERANCE);
+        minEdgeBetw = 1.4;
+        maxEdgeBetw = 3.4;
+        assertEquals((2.9 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e1.getBetweenness(), TOLERANCE);
+        assertEquals((2.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e2.getBetweenness(), TOLERANCE);
+        assertEquals((3.4 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e3.getBetweenness(), TOLERANCE);
+        assertEquals((1.4 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e4.getBetweenness(), TOLERANCE);
+        assertEquals((1.4 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e5.getBetweenness(), TOLERANCE);
+        assertEquals((3.3 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e6.getBetweenness(), TOLERANCE);
+        assertEquals((2.5 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e7.getBetweenness(), TOLERANCE);
+        assertEquals((1.9 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e8.getBetweenness(), TOLERANCE);
+        assertEquals((1.9 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e9.getBetweenness(), TOLERANCE);
+        assertEquals((2.8 - minEdgeBetw) / (maxEdgeBetw - minEdgeBetw), e10.getBetweenness(), TOLERANCE);
     }
 
     @Test
@@ -252,8 +260,6 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.23529411765
             }, graph);
         }
-        // Note: These happen to be the same results as in weightedDirectedTest
-        // but this is not always true.
         assertEquals(0.0 / 8, e1.getBetweenness(), TOLERANCE);
         assertEquals(8.0 / 8, e2.getBetweenness(), TOLERANCE);
         assertEquals(8.0 / 8, e3.getBetweenness(), TOLERANCE);

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/CormenAnalyzerTest.java
@@ -25,17 +25,18 @@
 package org.javanetworkanalyzer.analyzers.examples;
 
 import org.javanetworkanalyzer.analyzers.ManuallyCreatedGraphAnalyzerTest;
+import org.javanetworkanalyzer.analyzers.WeightedGraphAnalyzer;
 import org.javanetworkanalyzer.data.VCent;
 import org.javanetworkanalyzer.data.VUCent;
 import org.javanetworkanalyzer.data.VWCent;
-import org.javanetworkanalyzer.model.DirectedG;
-import org.javanetworkanalyzer.model.Edge;
-import org.javanetworkanalyzer.model.KeyedGraph;
-import org.javanetworkanalyzer.model.UndirectedG;
-import org.javanetworkanalyzer.model.WeightedKeyedGraph;
+import org.javanetworkanalyzer.graphcreators.GraphCreator;
+import org.javanetworkanalyzer.graphcreators.WeightedGraphCreator;
+import org.javanetworkanalyzer.model.*;
 import org.javanetworkanalyzer.progress.NullProgressMonitor;
 import org.javanetworkanalyzer.progress.ProgressMonitor;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests graph analyzers on the example graph in Figure 24.6 of Introduction to
@@ -62,39 +63,50 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
     private static final boolean CHECK_RESULTS = true;
     private static final int NUMBER_OF_NODES = 5;
 
+    private EdgeCent e1;
+    private EdgeCent e2;
+    private EdgeCent e3;
+    private EdgeCent e4;
+    private EdgeCent e5;
+    private EdgeCent e6;
+    private EdgeCent e7;
+    private EdgeCent e8;
+    private EdgeCent e9;
+    private EdgeCent e10;
+
     @Override
     protected void addEdges(
-            KeyedGraph<? extends VCent, Edge> graph) {
-        graph.addEdge(1, 2);
-        graph.addEdge(1, 4);
-        graph.addEdge(5, 1);
-        graph.addEdge(2, 4);
-        graph.addEdge(4, 2);
-        graph.addEdge(3, 5);
-        graph.addEdge(2, 3);
-        graph.addEdge(4, 3);
-        graph.addEdge(5, 3);
-        graph.addEdge(4, 5);
+            KeyedGraph<? extends VCent, EdgeCent> graph) {
+        e1 = graph.addEdge(1, 2);
+        e2 = graph.addEdge(1, 4);
+        e3 = graph.addEdge(5, 1);
+        e4 = graph.addEdge(2, 4);
+        e5 = graph.addEdge(4, 2);
+        e6 = graph.addEdge(2, 3);
+        e7 = graph.addEdge(4, 3);
+        e8 = graph.addEdge(3, 5);
+        e9 = graph.addEdge(5, 3);
+        e10 = graph.addEdge(4, 5);
     }
 
     @Override
     protected void addWeightedEdges(
-            WeightedKeyedGraph<? extends VCent, Edge> graph) {
-        graph.addEdge(1, 2).setWeight(10);
-        graph.addEdge(1, 4).setWeight(5);
-        graph.addEdge(5, 1).setWeight(7);
-        graph.addEdge(2, 4).setWeight(2);
-        graph.addEdge(4, 2).setWeight(3);
-        graph.addEdge(3, 5).setWeight(4);
-        graph.addEdge(2, 3).setWeight(1);
-        graph.addEdge(4, 3).setWeight(9);
-        graph.addEdge(5, 3).setWeight(6);
-        graph.addEdge(4, 5).setWeight(2);
+            WeightedKeyedGraph<? extends VCent, EdgeCent> graph) {
+        e1 = graph.addEdge(1, 2).setWeight(10);
+        e2 = graph.addEdge(1, 4).setWeight(5);
+        e3 = graph.addEdge(5, 1).setWeight(7);
+        e4 = graph.addEdge(2, 4).setWeight(2);
+        e5 = graph.addEdge(4, 2).setWeight(3);
+        e6 = graph.addEdge(2, 3).setWeight(1);
+        e7 = graph.addEdge(4, 3).setWeight(9);
+        e8 = graph.addEdge(3, 5).setWeight(4);
+        e9 = graph.addEdge(5, 3).setWeight(6);
+        e10 = graph.addEdge(4, 5).setWeight(2);
     }
 
     @Test
     public void unweightedDirectedTest() {
-        DirectedG<VUCent, Edge> graph =
+        DirectedG<VUCent, EdgeCent> graph =
                 super.unweightedDirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -115,7 +127,7 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void unweightedReversedTest() {
-        DirectedG<VUCent, Edge> graph =
+        DirectedG<VUCent, EdgeCent> graph =
                 super.unweightedReversedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -137,7 +149,7 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void unweightedUndirectedTest() {
-        UndirectedG<VUCent, Edge> graph =
+        UndirectedG<VUCent, EdgeCent> graph =
                 super.unweightedUndirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -158,9 +170,10 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
     }
 
     @Test
-    public void weightedDirectedTest() {
-        DirectedG<VWCent, Edge> graph =
+    public void weightedDirectedTest() throws Exception {
+        DirectedG<VWCent, EdgeCent> graph =
                 super.weightedDirectedAnalysis();
+
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
                 4.0 / 7,
@@ -177,11 +190,22 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
                 0.10000000000
             }, graph);
         }
+
+        assertEquals(0, e1.getBetweenness(), 0);
+        assertEquals(8, e2.getBetweenness(), 0);
+        assertEquals(8, e3.getBetweenness(), 0);
+        assertEquals(3, e4.getBetweenness(), 0);
+        assertEquals(6, e5.getBetweenness(), 0);
+        assertEquals(3, e6.getBetweenness(), 0);
+        assertEquals(0, e7.getBetweenness(), 0);
+        assertEquals(4, e8.getBetweenness(), 0);
+        assertEquals(1, e9.getBetweenness(), 0);
+        assertEquals(5, e10.getBetweenness(), 0);
     }
 
     @Test
     public void weightedReversedTest() {
-        DirectedG<VWCent, Edge> graph =
+        DirectedG<VWCent, EdgeCent> graph =
                 super.weightedReversedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -203,7 +227,7 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void weightedUndirectedTest() {
-        UndirectedG<VWCent, Edge> graph =
+        UndirectedG<VWCent, EdgeCent> graph =
                 super.weightedUndirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -234,7 +258,7 @@ public class CormenAnalyzerTest extends ManuallyCreatedGraphAnalyzerTest {
     }
 
     @Override
-    protected String getName() {
+    public String getName() {
         return CORMEN_GRAPH;
     }
 

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/ExampleGraphTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/ExampleGraphTest.java
@@ -61,7 +61,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Override
     protected void addEdges(
-            KeyedGraph<? extends VCent, Edge> graph) {
+            KeyedGraph<? extends VCent, EdgeCent> graph) {
         graph.addEdge(1, 2);
         graph.addEdge(1, 3);
         graph.addEdge(1, 5);
@@ -72,7 +72,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Override
     protected void addWeightedEdges(
-            WeightedKeyedGraph<? extends VCent, Edge> graph) {
+            WeightedKeyedGraph<? extends VCent, EdgeCent> graph) {
         graph.addEdge(1, 2).setWeight(1.2);
         graph.addEdge(1, 3).setWeight(0.8);
         graph.addEdge(1, 5).setWeight(1.0);
@@ -84,7 +84,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
     @Test
     public void unweightedDirectedTest()
             throws FileNotFoundException, NoSuchMethodException {
-        DirectedG<VUCent, Edge> graph =
+        DirectedG<VUCent, EdgeCent> graph =
                 super.unweightedDirectedAnalysis();
         if (CHECK_RESULTS) {
             // Max = 1.5, min = 0
@@ -104,7 +104,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
     @Test
     public void unweightedReversedTest()
             throws FileNotFoundException, NoSuchMethodException {
-        DirectedG<VUCent, Edge> graph =
+        DirectedG<VUCent, EdgeCent> graph =
                 super.unweightedReversedAnalysis();
         if (CHECK_RESULTS) {
             // Max = 1.5, min = 0
@@ -125,7 +125,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void unweightedUndirectedTest() {
-        UndirectedG<VUCent, Edge> graph =
+        UndirectedG<VUCent, EdgeCent> graph =
                 super.unweightedUndirectedAnalysis();
         if (CHECK_RESULTS) {
             // Max = 3, min = 0
@@ -147,7 +147,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void weightedDirectedTest() {
-        DirectedG<VWCent, Edge> graph =
+        DirectedG<VWCent, EdgeCent> graph =
                 super.weightedDirectedAnalysis();
         if (CHECK_RESULTS) {
             // Max = 1.5, min = 0
@@ -166,7 +166,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void weightedReversedTest() {
-        DirectedG<VWCent, Edge> graph =
+        DirectedG<VWCent, EdgeCent> graph =
                 super.weightedReversedAnalysis();
         if (CHECK_RESULTS) {
             // Max = 1.5, min = 0
@@ -186,7 +186,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
 
     @Test
     public void weightedUndirectedTest() {
-        UndirectedG<VWCent, Edge> graph =
+        UndirectedG<VWCent, EdgeCent> graph =
                 super.weightedUndirectedAnalysis();
         if (CHECK_RESULTS) {
             // Max = 4, min = 0
@@ -215,7 +215,7 @@ public class ExampleGraphTest extends ManuallyCreatedGraphAnalyzerTest {
     }
 
     @Override
-    protected String getName() {
+    public String getName() {
         return EXAMPLE_GRAPH;
     }
 

--- a/src/test/java/org/javanetworkanalyzer/analyzers/examples/Graph2DAnalyzerTest.java
+++ b/src/test/java/org/javanetworkanalyzer/analyzers/examples/Graph2DAnalyzerTest.java
@@ -29,6 +29,7 @@ import org.javanetworkanalyzer.data.VUCent;
 import org.javanetworkanalyzer.data.VWCent;
 import org.javanetworkanalyzer.model.DirectedG;
 import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.model.EdgeCent;
 import org.javanetworkanalyzer.model.UndirectedG;
 import org.javanetworkanalyzer.progress.NullProgressMonitor;
 import org.javanetworkanalyzer.progress.ProgressMonitor;
@@ -55,7 +56,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
 
     @Test
     public void unweightedDirectedTest() {
-        DirectedG<VUCent, Edge> graph =
+        DirectedG<VUCent, EdgeCent> graph =
                 super.unweightedDirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -69,7 +70,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
 
     @Test
     public void unweightedReversedTest() {
-        DirectedG<VUCent, Edge> graph =
+        DirectedG<VUCent, EdgeCent> graph =
                 super.unweightedReversedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -83,7 +84,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
 
     @Test
     public void unweightedUndirectedTest() {
-        UndirectedG<VUCent, Edge> graph =
+        UndirectedG<VUCent, EdgeCent> graph =
                 super.unweightedUndirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -97,7 +98,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
 
     @Test
     public void weightedDirectedTest() {
-        DirectedG<VWCent, Edge> graph =
+        DirectedG<VWCent, EdgeCent> graph =
                 super.weightedDirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -111,7 +112,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
 
     @Test
     public void weightedReversedTest() {
-        DirectedG<VWCent, Edge> graph =
+        DirectedG<VWCent, EdgeCent> graph =
                 super.weightedReversedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -125,7 +126,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
 
     @Test
     public void weightedUndirectedTest() {
-        UndirectedG<VWCent, Edge> graph =
+        UndirectedG<VWCent, EdgeCent> graph =
                 super.weightedUndirectedAnalysis();
         if (CHECK_RESULTS) {
             checkBetweenness(new double[]{
@@ -155,7 +156,7 @@ public class Graph2DAnalyzerTest extends GraphAnalyzerTest {
     }
 
     @Override
-    protected String getName() {
+    public String getName() {
         return GRAPH2D;
     }
 

--- a/src/test/java/org/javanetworkanalyzer/graphcreators/CormenGraphPrep.java
+++ b/src/test/java/org/javanetworkanalyzer/graphcreators/CormenGraphPrep.java
@@ -27,6 +27,7 @@ package org.javanetworkanalyzer.graphcreators;
 import org.javanetworkanalyzer.data.VAccess;
 import org.javanetworkanalyzer.model.DirectedWeightedPseudoG;
 import org.javanetworkanalyzer.model.Edge;
+import org.javanetworkanalyzer.model.EdgeCent;
 
 /**
  * Prepares the Cormen graph.
@@ -45,7 +46,7 @@ import org.javanetworkanalyzer.model.Edge;
 //         \ v| /    2     \v|
 //          > 4 -----------> 5
 //               CORMEN
-public class CormenGraphPrep extends GraphPrep<VAccess, Edge> {
+public class CormenGraphPrep extends GraphPrep<VAccess, EdgeCent> {
 
     @Override
     public int getNumberOfVertices() {
@@ -53,10 +54,10 @@ public class CormenGraphPrep extends GraphPrep<VAccess, Edge> {
     }
 
     @Override
-    public DirectedWeightedPseudoG<VAccess, Edge> weightedDirected() throws
+    public DirectedWeightedPseudoG<VAccess, EdgeCent> weightedDirected() throws
             NoSuchMethodException {
-        DirectedWeightedPseudoG<VAccess, Edge> g =
-                new DirectedWeightedPseudoG<VAccess, Edge>(VAccess.class, Edge.class);
+        DirectedWeightedPseudoG<VAccess, EdgeCent> g =
+                new DirectedWeightedPseudoG<VAccess, EdgeCent>(VAccess.class, EdgeCent.class);
         g.addEdge(1, 2).setWeight(10);
         g.addEdge(1, 4).setWeight(5);
         g.addEdge(5, 1).setWeight(7);


### PR DESCRIPTION
Here I implement the edge betweenness calculation. This implementation allows for multiple shortest paths. I have included unit tests for (un)directed (un)weighted (and possibly edge-reversed) networks.

The values are normalized.

Fixes #33.
